### PR TITLE
Revision in Towers ( line 103)

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ The tile object can be attached with different functionalities dynamically depen
 
 
 #### Towers:
-Purpose: Since the whole game is about tower defence, the tower is indeed the most significant part of it. The game support 5 various types of tower which are Tank Tower (taunt enemies hatred), Range Tower (low attack damage but long attack range), Slow Tower (slow nearby enemies), Heal Tower (heal nearby ally towers) and Gold Tower (generate golds). Each of these towers has its unique pros and cons, user needs to combine them properly to defend the base as long as possible.
+Purpose: Since the game is about tower defence, the tower plays a significant role. The game support 5 various types of tower which are Tank Tower (taunt enemies hatred), Range Tower (low attack damage but long attack range), Slow Tower (slow nearby enemies), Heal Tower (heal nearby ally towers) and Gold Tower (generate golds). Users should combine different towers properly to defend the base because Each type of tower has unique pros and cons.
 
 Iterator:
 Tower Controller uses Iterator design pattern to control tower game object (aka prefab). More specifically, there are total 5 different type of towers. These tower scripts and different initial variables are assigned into 5 different tower prefabs respectively. The Tower Controller does not need to know what these towers are capable of, it just provides a way to access this tower prefabs when the Tile Event Handler need them.


### PR DESCRIPTION
1. In line 103, the sentence " Since the ... part of it " is too long and contains empty words.
Delete " whole ", " indeed " and " the most " to avoid use empty words.
Rewrite the sentence to " Since the game is about tower defense, the tower plays a significant role. 

2. In the last sentence of line 103, the first part " each of these ... pros and cons. " 
Rewrite the word " each " from pronoun to adjective.
In the second part " user needs to ... as long as possible. " 
Delete " as long as possible " avoid function words.
Add a " because " in the front of the first part because the first part is the reason for the second part to improve cohesion.
Rewrite the sentence to " Users should combine different towers properly to defend the base because Each type of tower has unique pros and cons. "

Fix #10

